### PR TITLE
Cassandra's version 2.1.9 has been removed from apt.

### DIFF
--- a/install/optional-01-cassandra.sh
+++ b/install/optional-01-cassandra.sh
@@ -7,7 +7,7 @@
 echo
 echo
 echo "Installing Cassandra"
-export CASSANDRA_VERSION=2.1.9
+export CASSANDRA_VERSION=2.1.14
 
 apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 514A2AD631A57A16DD0047EC749D6EEC0353B12C
 echo 'deb http://www.apache.org/dist/cassandra/debian 21x main' > /etc/apt/sources.list.d/cassandra.list


### PR DESCRIPTION
So installation of this package failed.
Changed to 2.1.14 (same major and minor, so should be compatible), which is available to install.
